### PR TITLE
Remove id attribute from paper-menu-button element

### DIFF
--- a/paper-swatch-picker.html
+++ b/paper-swatch-picker.html
@@ -114,7 +114,7 @@ Custom property | Description | Default
       }
     </style>
 
-    <paper-menu-button id="menu" vertical-align="[[verticalAlign]]" horizontal-align="[[horizontalAlign]]">
+    <paper-menu-button vertical-align="[[verticalAlign]]" horizontal-align="[[horizontalAlign]]">
       <paper-icon-button
           id="iconButton"
           icon="swatch:format-color-fill"


### PR DESCRIPTION
This prevents potential conflicts with document scripts.