### PR TITLE
Add icon property to bind to paper-icon-button

### DIFF
--- a/paper-swatch-picker.html
+++ b/paper-swatch-picker.html
@@ -206,6 +206,7 @@ Custom property | Description | Default
         /**
          * The name of the icon to use for the button used as a dropdown trigger.
          * The name should be of the form: `iconset_name:icon_name`.
+         * You must manually import the icon/iconset you wish you use.
          */
         icon: {
           type: String,

--- a/paper-swatch-picker.html
+++ b/paper-swatch-picker.html
@@ -117,7 +117,7 @@ Custom property | Description | Default
     <paper-menu-button vertical-align="[[verticalAlign]]" horizontal-align="[[horizontalAlign]]">
       <paper-icon-button
           id="iconButton"
-          icon="swatch:format-color-fill"
+          icon="[[icon]]"
           slot="dropdown-trigger" class="dropdown-trigger"
           alt="color picker"
           noink$="[[noink]]">
@@ -201,6 +201,15 @@ Custom property | Description | Default
           type: String,
           value: 'top',
           reflectToAttribute: true
+        },
+
+        /**
+         * The name of the icon to use for the button used as a dropdown trigger.
+         * The name should be of the form: `iconset_name:icon_name`.
+         */
+        icon: {
+          type: String,
+          value: 'swatch:format-color-fill'
         },
 
         /**


### PR DESCRIPTION
Currently the only way to change the icon is by piercing the shadow dom as:
```javascript
<document|this>.querySelector('paper-swatch-picker').$.iconButton.icon = 'menu';
```
This adds an `icon` property bound to `paper-icon-button.icon` to allow changing icon at load time, without any id's that may change in the future.

PS: I guess this would have to be merged into 2.0-preview after master? I wasn't sure which would be better to set this PR against.