### PR TITLE
set color property programmatically

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -48,7 +48,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <h3>The palette used by the color picker can be configured</h3>
       <demo-snippet class="centered-demo">
         <template>
-          <paper-swatch-picker column-count=5 color-list='["#65a5f2", "#2b63ba", "#83be54", "#3b8638", "#f0d551", "#d7be48", "#e5943c", "#cf712e", "#a96ddb", "#6f4196"]' ></paper-swatch-picker>
+          <paper-swatch-picker column-count=5 color-list="['#65a5f2', '#2b63ba', '#83be54', '#3b8638', '#f0d551', '#d7be48', '#e5943c', '#cf712e', '#a96ddb', '#6f4196']" ></paper-swatch-picker>
         </template>
       </demo-snippet>
 

--- a/paper-swatch-picker.html
+++ b/paper-swatch-picker.html
@@ -304,9 +304,12 @@ Custom property | Description | Default
           sizeOfAColorDiv = sizeOfAColorDiv.replace('px', '');
         }
 
-        var rowCount = this.colorList.length / this.columnCount;
+        var rowCount = Math.ceil(this.colorList.length / this.columnCount);
+        // get empty columns due to vertical layout: 1 color and 2 columns or 12 colors and 5 columns
+        var emptyColumns = ((rowCount * this.columnCount) - this.colorList.length) / rowCount;
         this.$.container.style.height = rowCount * sizeOfAColorDiv + 'px';
-        this.$.container.style.width = this.columnCount * sizeOfAColorDiv + 'px';
+        this.$.container.style.width = (this.columnCount - emptyColumns) * sizeOfAColorDiv + 'px';
+        this.$.container.style['padding-right'] = emptyColumns * sizeOfAColorDiv + 'px';
         this._renderedColors = false;
       }
     });

--- a/paper-swatch-picker.html
+++ b/paper-swatch-picker.html
@@ -121,8 +121,8 @@ Custom property | Description | Default
           noink$="[[noink]]">
       </paper-icon-button>
       <paper-listbox slot="dropdown-content" class="dropdown-content" id="container">
-        <template is="dom-repeat" items="{{colorList}}">
-          <paper-item class="color">{{item}}</paper-item>
+        <template is="dom-repeat" items="{{colorList}}" as="color">
+          <paper-item data-color$="[[color]]" class="color">{{color}}</paper-item>
         </template>
       </paper-listbox>
     </paper-menu-button>
@@ -272,16 +272,12 @@ Custom property | Description | Default
 
       _onColorTap: function(event) {
         var item = event.detail.item;
-        // The inner `span` element has the background color;
-        var color = item.style.color;
-
-        // If it's in rgb format, convert it first.
-        this.color = color.indexOf('rgb') === -1 ? color : this._rgbToHex(color);
+        this.color = item.dataset.color;;
         this.fire('color-picker-selected', {color: this.color});
       },
 
       _colorChanged: function() {
-        this.$.iconButton.style.color = this.color;
+        this.$.iconButton.style.color = this.color || 'black';
         this.$.container.selected = this.colorList.indexOf(this.color);
       },
 
@@ -295,23 +291,6 @@ Custom property | Description | Default
 
       _columnCountChanged: function() {
         this._updateSize();
-      },
-
-      /**
-       * Takes an rgb(r, g, b) style string and converts it to a #ffffff hex value.
-       */
-      _rgbToHex: function(rgb) {
-        // Split the rgb(r, g, b) string up.
-        var split = rgb.split('(')[1].split(')')[0].split(',');
-
-        if (split.length != 3)
-          return '';
-
-        // From https://gist.github.com/lrvick/2080648.
-        var bin = split[0] << 16 | split[1] << 8 | split[2];
-        return (function(h) {
-          return '#' + new Array(7 - h.length).join('0') + h;
-        })(bin.toString(16).toLowerCase());
       },
 
       _updateSize: function() {

--- a/paper-swatch-picker.html
+++ b/paper-swatch-picker.html
@@ -282,6 +282,7 @@ Custom property | Description | Default
 
       _colorChanged: function() {
         this.$.iconButton.style.color = this.color;
+        this.$.container.selected = this.colorList.indexOf(this.color);
       },
 
       _colorListChanged: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -54,7 +54,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <script>
+  <script>     
+  
+    var _rgbToHex = function(rgb) {
+      // Split the rgb(r, g, b) string up.
+      var split = rgb.split('(')[1].split(')')[0].split(',');
+      if (split.length != 3)
+        return '';
+      // From https://gist.github.com/lrvick/2080648.
+      var bin = split[0] << 16 | split[1] << 8 | split[2];
+      return (function(h) {
+        return '#' + new Array(7 - h.length).join('0') + h;
+      })(bin.toString(16).toLowerCase());
+    }
+
     suite('basic', function() {
       var picker, container;
 
@@ -78,7 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           // The colors have been filled in. The first box is #ffebee.
           var box = container.querySelector('.color');
-          assert.equal('#ffebee', picker._rgbToHex(box.style.color));
+          assert.equal('#ffebee', _rgbToHex(box.style.color));
           done();
         }, 1);
       });
@@ -96,11 +109,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           MockInteractions.tap(box);
           Polymer.Base.async(function() {
             assert.equal('#ffebee', picker.color);
-            assert.equal('#ffebee', picker._rgbToHex(picker.$.iconButton.style.color));
+            assert.equal('#ffebee', _rgbToHex(picker.$.iconButton.style.color));
             done();
           }, 1);
         });
       });
+
+      test('setting color property change button color', function(done) {
+        Polymer.dom.flush();
+
+        // No color is selected.
+        assert.equal(picker.color, undefined);
+
+        Polymer.Base.async(function() {
+          // The colors have been filled in. The first box is #ffebee.
+          picker.color = '#ffcdd2'
+          Polymer.Base.async(function() {
+            assert.equal('#ffcdd2', _rgbToHex(picker.$.iconButton.style.color));
+            done();
+          }, 1);
+        });
+      });
+
+      test('setting color property change selected color', function(done) {
+        Polymer.dom.flush();
+
+        // No color is selected.
+        assert.equal(picker.color, undefined);
+
+        Polymer.Base.async(function() {
+          // The colors have been filled in. The first box is #ffebee.
+          picker.color = '#ffcdd2'
+          Polymer.Base.async(function() {
+            MockInteractions.tap(picker.$.iconButton);
+            var box = container.querySelector('.color.iron-selected');
+            assert.equal('#ffcdd2', _rgbToHex(box.style.color));
+            done();
+          }, 1);
+        });
+      });
+
     });
 
     suite('initial selection', function() {
@@ -114,13 +162,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('the picker can have an initially selected color', function() {
         Polymer.dom.flush();
         assert.equal(picker.color, '#ffcdd2');
-        assert.equal('#ffcdd2', picker._rgbToHex(picker.$.iconButton.style.color));
+        assert.equal('#ffcdd2', _rgbToHex(picker.$.iconButton.style.color));
       });
 
       test('selecting a different color updates the button color', function(done) {
         Polymer.dom.flush();
         assert.equal(picker.color, '#ffcdd2');
-        assert.equal('#ffcdd2', picker._rgbToHex(picker.$.iconButton.style.color));
+        assert.equal('#ffcdd2', _rgbToHex(picker.$.iconButton.style.color));
 
         MockInteractions.tap(picker.$.iconButton);
 
@@ -130,7 +178,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           MockInteractions.tap(box);
           Polymer.Base.async(function() {
             assert.equal('#ffebee', picker.color);
-            assert.equal('#ffebee', picker._rgbToHex(picker.$.iconButton.style.color));
+            assert.equal('#ffebee', _rgbToHex(picker.$.iconButton.style.color));
             done();
           }, 1);
         }, 1);
@@ -159,11 +207,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           // The colors have been filled in correctly
           var boxes = container.querySelectorAll('.color');
-          assert.equal('#ff0000', picker._rgbToHex(boxes[0].style.color));
-          assert.equal('#00ff00', picker._rgbToHex(boxes[1].style.color));
-          assert.equal('#0000ff', picker._rgbToHex(boxes[2].style.color));
-          assert.equal('#000000', picker._rgbToHex(boxes[3].style.color));
-          assert.equal('#ffffff', picker._rgbToHex(boxes[4].style.color));
+          assert.equal('#ff0000', _rgbToHex(boxes[0].style.color));
+          assert.equal('#00ff00', _rgbToHex(boxes[1].style.color));
+          assert.equal('#0000ff', _rgbToHex(boxes[2].style.color));
+          assert.equal('#000000', _rgbToHex(boxes[3].style.color));
+          assert.equal('#ffffff', _rgbToHex(boxes[4].style.color));
           done();
         }, 1);
       });
@@ -230,7 +278,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               // Since the old selected color is not in the new list,
               // it has been adjusted to the fallback color (first color: #ffcdd2)
               assert.equal('#ffcdd2', picker.color);
-              assert.equal('#ffcdd2', picker._rgbToHex(picker.$.iconButton.style.color));
+              assert.equal('#ffcdd2', _rgbToHex(picker.$.iconButton.style.color));
 
               MockInteractions.tap(picker.$.iconButton);
 
@@ -238,7 +286,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 // The colors have been filled in correctly
                 var boxes = container.querySelectorAll('.color');
                 picker.colorList.forEach(function(color, index) {
-                  assert.equal(color, picker._rgbToHex(boxes[index].style.color))
+                  assert.equal(color, _rgbToHex(boxes[index].style.color))
                 });
 
                 done();


### PR DESCRIPTION
Hello PolymerElements Team,
this is a proposal to resolve the fact that we can't set color property programmatically and get the color container selected-item updated. Changes are : 
- use a dataset : data-color attached to the item color, so _rgbToHex is not need anymore and is move in test.
- set the container selected/index to the color index.
- default to black if no color
- add related tests

this should close #10 
Regards,
Cyrille.