### PR TITLE
Added currentColor to underlying .color menu item

### DIFF
--- a/paper-swatch-picker.html
+++ b/paper-swatch-picker.html
@@ -68,6 +68,7 @@ Custom property | Description | Default
         cursor: pointer;
         font-size: 0;
         position: relative;
+        background-color: currentColor;
       }
 
       /* If we just scale the paper-item when hovering, this will end up


### PR DESCRIPTION
This is a fix for https://github.com/PolymerElements/paper-swatch-picker/issues/32 - by having the background-color set we avoid a flash of the background as the drop down opens.