### PR TITLE
Defer paper-item creation to first open for enormous performance improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@polymer/paper-swatch-picker",
+  "name": "@tadevel/paper-lazy-swatch-picker",
   "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/PolymerElements/paper-swatch-picker.git"
+    "url": "git@github.com:aletorrado/paper-swatch-picker.git"
   },
   "homepage": "https://github.com/PolymerElements/paper-swatch-picker",
-  "name": "@polymer/paper-swatch-picker",
+  "name": "@tadevel/paper-lazy-swatch-picker",
   "license": "BSD-3-Clause",
   "devDependencies": {
     "webmat": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "generate-types": "gen-typescript-declarations --deleteExisting --outDir . --verify",
     "prepare": "npm run generate-types"
   },
-  "version": "3.0.1-hotfix.1",
+  "version": "3.0.1-hotfix.2",
   "main": "paper-swatch-picker.js",
   "author": "The Polymer Authors",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "generate-types": "gen-typescript-declarations --deleteExisting --outDir . --verify",
     "prepare": "npm run generate-types"
   },
-  "version": "3.0.1",
+  "version": "3.0.1-hotfix.1",
   "main": "paper-swatch-picker.js",
   "author": "The Polymer Authors",
   "dependencies": {

--- a/paper-swatch-picker.js
+++ b/paper-swatch-picker.js
@@ -238,6 +238,7 @@ Polymer({
     // Fill in the colors if we haven't already.
     if (this._renderedColors)
       return;
+    this.$.container.innerHTML = '';
     for (let color of this.colorList) {
       let item = document.createElement('paper-item');
       item.classList.add('color');

--- a/paper-swatch-picker.js
+++ b/paper-swatch-picker.js
@@ -116,12 +116,14 @@ Polymer({
       }
     </style>
 
-    <paper-menu-button vertical-align="[[verticalAlign]]" horizontal-align="[[horizontalAlign]]">
+    <paper-menu-button vertical-align="[[verticalAlign]]" horizontal-align="[[horizontalAlign]]" opened="{{opened}}">
       <paper-icon-button id="iconButton" icon="[[icon]]" slot="dropdown-trigger" class="dropdown-trigger" alt="color picker" noink$="[[noink]]">
       </paper-icon-button>
       <paper-listbox slot="dropdown-content" class="dropdown-content" id="container">
-        <template is="dom-repeat" items="[[colorList]]">
-          <paper-item class="color">[[item]]</paper-item>
+        <template is="dom-if" if="[[opened]]">
+          <template is="dom-repeat" items="[[colorList]]">
+            <paper-item class="color">[[item]]</paper-item>
+          </template>
         </template>
       </paper-listbox>
     </paper-menu-button>
@@ -240,15 +242,17 @@ Polymer({
   },
 
   _onOpen: function() {
-    // Fill in the colors if we haven't already.
-    if (this._renderedColors)
-      return;
+    setTimeout(()=>{
+      // Fill in the colors if we haven't already.
+      if (this._renderedColors)
+        return;
 
-    var colorBoxes = this.$.container.querySelectorAll('.color');
-    for (var i = 0; i < colorBoxes.length; i++) {
-      colorBoxes[i].style.color = colorBoxes[i].innerHTML;
-    }
-    this._renderedColors = true;
+      var colorBoxes = this.$.container.querySelectorAll('.color');
+      for (var i = 0; i < colorBoxes.length; i++) {
+        colorBoxes[i].style.color = colorBoxes[i].innerHTML;
+      }
+      this._renderedColors = true;
+    }, 0)
   },
 
   _addOverflowClass: function() {

--- a/paper-swatch-picker.js
+++ b/paper-swatch-picker.js
@@ -50,7 +50,6 @@ Custom property | Description | Default
 @demo demo/index.html
 */
 Polymer({
-  /** @override */
   _template: html`
     <style>
       :host {
@@ -116,15 +115,10 @@ Polymer({
       }
     </style>
 
-    <paper-menu-button vertical-align="[[verticalAlign]]" horizontal-align="[[horizontalAlign]]" opened="{{opened}}">
-      <paper-icon-button id="iconButton" icon="[[icon]]" slot="dropdown-trigger" class="dropdown-trigger" alt="color picker" noink$="[[noink]]">
+    <paper-menu-button vertical-align="[[verticalAlign]]" horizontal-align="[[horizontalAlign]]">
+      <paper-icon-button id="iconButton" icon="[[icon]]" slot="dropdown-trigger" class="dropdown-trigger" alt="color picker" noink\$="[[noink]]">
       </paper-icon-button>
       <paper-listbox slot="dropdown-content" class="dropdown-content" id="container">
-        <template is="dom-if" if="[[opened]]">
-          <template is="dom-repeat" items="[[colorList]]">
-            <paper-item class="color">[[item]]</paper-item>
-          </template>
-        </template>
       </paper-listbox>
     </paper-menu-button>
 `,
@@ -193,7 +187,6 @@ Polymer({
     noink: {type: Boolean}
   },
 
-  /** @override */
   attached: function() {
     // Note: we won't actually render these color boxes unless the menu is
     // actually tapped.
@@ -204,7 +197,7 @@ Polymer({
   /**
    * Returns the default Material Design colors.
    *
-   * @return {!Array<string>}
+   * @return {Array[string]}
    */
   defaultColors: function() {
     return [
@@ -242,17 +235,16 @@ Polymer({
   },
 
   _onOpen: function() {
-    setTimeout(()=>{
-      // Fill in the colors if we haven't already.
-      if (this._renderedColors)
-        return;
-
-      var colorBoxes = this.$.container.querySelectorAll('.color');
-      for (var i = 0; i < colorBoxes.length; i++) {
-        colorBoxes[i].style.color = colorBoxes[i].innerHTML;
-      }
-      this._renderedColors = true;
-    }, 0)
+    // Fill in the colors if we haven't already.
+    if (this._renderedColors)
+      return;
+    for (let color of this.colorList) {
+      let item = document.createElement('paper-item');
+      item.classList.add('color');
+      item.innerHTML = item.style.color = color;
+      this.$.container.appendChild(item);
+    }
+    this._renderedColors = true;
   },
 
   _addOverflowClass: function() {


### PR DESCRIPTION
Hi, I've noticed a big performance penalty just by having about 20 paper-swatch-picker on a single page. 

After research, it seems related to paper-item initialization, so I just deferred the paper-item creation to the first open event.

Previously there was a very similar strategy in place, probably for performance reasons as well, where the styling was applied on the first open event, so the change that was made is pretty simple.